### PR TITLE
ci: add pr linter

### DIFF
--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -1,0 +1,21 @@
+name: pr-linter
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: lint pr title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,0 @@
-pnpm dlx commitlint --edit $1

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,0 @@
-export default { extends: ['@commitlint/config-conventional'] };

--- a/package.json
+++ b/package.json
@@ -1,14 +1,5 @@
 {
     "name": "remembit",
     "description": "",
-    "version": "0.2.0",
-    "type": "module",
-    "devDependencies": {
-        "@commitlint/cli": "^19.3.0",
-        "@commitlint/config-conventional": "^19.2.2",
-        "husky": "^9.0.11"
-    },
-    "scripts": {
-        "prepare": "husky"
-    }
+    "version": "0.2.0"
 }


### PR DESCRIPTION
## About

This simplifies commit message format enforcement. All commits must come through a squash merged PR and the title must follow conventional commit format.

### Add

- PR linter workflow

### Remove

- Husky 